### PR TITLE
fix: add newly required nullability flag

### DIFF
--- a/lib/src/data_class_generator.dart
+++ b/lib/src/data_class_generator.dart
@@ -112,7 +112,7 @@ class DataClassGenerator extends GeneratorForAnnotation<DataClass> {
     for (final annotation in field.metadata) {
       final obj = annotation.computeConstantValue();
       
-      if (obj != null && obj.type?.getDisplayString() == 'DataField') {
+      if (obj != null && obj.type?.getDisplayString(withNullability: false) == 'DataField') {
         return _DataFieldSpec.parse(obj);
       }
     }


### PR DESCRIPTION
Since Flutter 3.35.0 the `withNullability` flag is required in the `getDisplayString` method of a type. 